### PR TITLE
이메일 인증 모달, 스페이스 리스트 모달, 페이지 권한 수정

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ MPA를 구현 "react-router-dom": "^6.9.0", <br />
 스타일 사용 "styled-components": "^5.3.9", <br />
 "universal-cookie": "^4.0.4", <br />
 "web-vitals": "^2.1.0" <br />
-/////////////////////////////////////////////////////은선만 설치
 팀원들과 기본적인 코드 통일 "prettier": "^2.8.7", <br />
 유효성 검사 라이브러리 "yup": "^1.0.2"
-react-icons
+아이콘 사용 : react-icons
+alert창 라이브러리 : react-toastify

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "react-redux": "^8.0.5",
     "react-router-dom": "^6.10.0",
     "react-scripts": "5.0.1",
+    "react-toastify": "^9.1.2",
     "redux": "^4.2.1",
     "sheet": "^0.2.0",
     "style": "^0.0.3",

--- a/src/axios/api.js
+++ b/src/axios/api.js
@@ -14,26 +14,25 @@ api.interceptors.response.use(
     const originalConfig = error.config;
     console.log(originalConfig);
 
-    if (error.response.data.statusCode === 401 && !originalConfig._retry) {
+    if (error.response.data.statusCode === 401 && originalConfig._retry) {
       originalConfig._retry = true;
-      console.log();
 
-      // try {
-      //   const refreshToken = cookies.get('refresh_token');
+      try {
+        const refreshToken = cookies.get('refresh_token');
 
-      //   const data = await api.get('users/refresh', {
-      //     headers: {
-      //       refresh_token: `Bearer ${refreshToken}`,
-      //     },
-      //   });
-      //   const newToken = data.headers['authorization'].split(' ')[1];
+        const data = await api.get('users/refresh', {
+          headers: {
+            refresh_token: `Bearer ${refreshToken}`,
+          },
+        });
+        const newToken = data.headers['authorization'].split(' ')[1];
 
-      //   cookies.set('token', newToken, { path: '/', expires: 14 });
+        cookies.set('token', newToken, { path: '/', expires: 14 });
 
-      //   return await api.request(originalConfig);
-      // } catch (error) {
-      //   console.log(error);
-      // }
+        return await api.request(originalConfig);
+      } catch (error) {
+        console.log(error);
+      }
     }
     return Promise.reject(error);
   },

--- a/src/features/adminSpace/AdminList.jsx
+++ b/src/features/adminSpace/AdminList.jsx
@@ -34,12 +34,8 @@ function AdminList({
   return (
     <>
       {isModal ? (
-        <ModalBackground
-          onClick={() => {
-            setIsModal(!isModal);
-          }}
-        >
-          <Modal onClick={e => e.stopPropagation()}>
+        <ModalBackground>
+          <Modal>
             <ModalList>
               <ModalHeader>
                 <ModalTitle>관리하기</ModalTitle>

--- a/src/features/space/SpaceBox.jsx
+++ b/src/features/space/SpaceBox.jsx
@@ -106,7 +106,7 @@ function SpaceBox({ spaceId, selectedSpace }) {
           })}
         </Row>
         <Row>
-          {role === 'ADMIN' ? (
+          {role === 'ADMIN' || role === 'MANAGER' ? (
             <StBtn onClick={() => navi('/adminSpace')}>관리하기</StBtn>
           ) : null}
         </Row>

--- a/src/features/user/Certification.jsx
+++ b/src/features/user/Certification.jsx
@@ -7,20 +7,25 @@ import {
   InlineInput,
   SterrorFont,
 } from '../../pages/user/UserStyled';
+import { toast, ToastContainer } from 'react-toastify';
+import 'react-toastify/dist/ReactToastify.css';
 
 function Certification({ admin, email ,onChange, errors}) {
   
-
   const submitBtnHandler = async e => {
     e.preventDefault();
 
     try {
       const response = await api.post('/users/signup/email', admin);
-      alert('이메일로 인증번호를 보냈습니다.');
+      const newResponse = response.data.message;
+      console.log(newResponse);
+      toast(`${newResponse}`);
+      // alert('이메일로 인증번호를 보냈습니다.');
       return response;
     } catch (error) {
-      const errorMsg = error.response.data.message;
-      alert(`${errorMsg}`);
+      const errorMsg = error.response.data.message;      
+      console.log(errorMsg);
+      toast(`${errorMsg}`);
       return error;
     }
   };
@@ -55,6 +60,19 @@ function Certification({ admin, email ,onChange, errors}) {
           value="인증받기"
         />
       </Container>
+
+      <ToastContainer
+        position="top-right" // 알람 위치 지정
+        autoClose={3000} // 자동 off 시간
+        hideProgressBar={false} // 진행시간바 숨김
+        closeOnClick // 클릭으로 알람 닫기
+        rtl={false} // 알림 좌우 반전
+        pauseOnFocusLoss // 화면을 벗어나면 알람 정지
+        draggable // 드래그 가능
+        pauseOnHover // 마우스를 올리면 알람 정지
+        theme="light"
+        limit={1} // 알람 개수 제한
+      />
 
       <SterrorFont>
         {errors.email && (

--- a/src/features/user/CertificationCkeck.jsx
+++ b/src/features/user/CertificationCkeck.jsx
@@ -2,6 +2,8 @@ import React from 'react';
 import api from '../../axios/api';
 import {  Container, InlinButton, InlineInput } from '../../pages/user/UserStyled';
 import { StSmallFont } from '../../pages/Welcome/WelcomeStyled';
+import { toast, ToastContainer } from 'react-toastify';
+import 'react-toastify/dist/ReactToastify.css';
 
 function CertificationCkeck({ user,certification, onChange }) {
 
@@ -11,19 +13,16 @@ function CertificationCkeck({ user,certification, onChange }) {
     e.preventDefault();
     try {
       const response = await api.post('/users/signup/match', user);
-      console.log('인증번호',response);
       const newResponse = response.data.message;
-      alert(`${newResponse}`);
+      toast(`${newResponse}`);
       return newResponse;
     } catch (error) {
-      console.log('인증번호',error);
       const errorMsg = error.response.data.message;
-      alert(`${errorMsg}`);
+      toast(`${errorMsg}`);
       return error;
     }
   };
-
-
+  
   return (
     <>
     <Container>
@@ -55,6 +54,19 @@ function CertificationCkeck({ user,certification, onChange }) {
       value="인증확인"
       />
     </Container>
+
+      <ToastContainer
+        position="top-right" // 알람 위치 지정
+        autoClose={3000} // 자동 off 시간
+        hideProgressBar={false} // 진행시간바 숨김
+        closeOnClick // 클릭으로 알람 닫기
+        rtl={false} // 알림 좌우 반전
+        pauseOnFocusLoss // 화면을 벗어나면 알람 정지
+        draggable // 드래그 가능
+        pauseOnHover // 마우스를 올리면 알람 정지
+        theme="light"
+        limit={1} // 알람 개수 제한
+      />
     </>
   );
 }

--- a/src/hooks/adminSpace/useAdminSpaceHook.js
+++ b/src/hooks/adminSpace/useAdminSpaceHook.js
@@ -65,7 +65,7 @@ export function useFloorsAndSpaces(navi) {
 
     if (token === undefined) {
       navi('/');
-    } else if (role === 'ADMIN') {
+    } else if (role === 'ADMIN' || role === 'MANAGER') {
       dispatch(__getSpaces());
       dispatch(__getFloors());
     } else {

--- a/src/hooks/useAdminSpaceHook.js
+++ b/src/hooks/useAdminSpaceHook.js
@@ -56,7 +56,7 @@ export function useFloorsAndSpaces(navi) {
 
     if (token === undefined) {
       navi('/');
-    } else if (role === 'ADMIN') {
+    } else if (role === 'ADMIN' || role === 'MANAGER') {
       dispatch(__getSpaces());
       dispatch(__getFloors());
     } else {

--- a/src/pages/space/Space.jsx
+++ b/src/pages/space/Space.jsx
@@ -183,7 +183,7 @@ function Space() {
                   {/* space name 부분 */}
                   <Row></Row>
                   <Row>
-                    {role === 'ADMIN' ? (
+                    {role === 'ADMIN' || role === 'MANAGER' ? (
                       <StBtn onClick={() => navi('/adminSpace')}>
                         관리하기
                       </StBtn>

--- a/src/pages/user/Management.jsx
+++ b/src/pages/user/Management.jsx
@@ -36,7 +36,7 @@ function Management() {
   useEffect(() => {
     if (!token) {
       navi('/');
-    } else if (role !== 'ADMIN') {
+    } else if (role === 'USER') {
       navi('/');
     } else {
       const loadData = async () => {
@@ -78,14 +78,11 @@ function Management() {
           <InfoContain>
             {userList.map(item => (
               <InfoBox key={item.userId}>
-                <StSubTitle>
-                  {item.username}
-                </StSubTitle>
+                <StSubTitle>{item.username}</StSubTitle>
 
                 <Info>
                   <CommentBox>
                     <StSmallFont width>
-                      
                       <HiOutlineMail /> 이메일
                     </StSmallFont>
                     <br />

--- a/yarn.lock
+++ b/yarn.lock
@@ -3365,6 +3365,11 @@ cliui@^8.0.1:
     strip-ansi "^6.0.1"
     wrap-ansi "^7.0.0"
 
+clsx@^1.1.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/clsx/-/clsx-1.2.1.tgz#0ddc4a20a549b59c93a4116bb26f5294ca17dc12"
+  integrity sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==
+
 co@^4.6.0:
   version "4.6.0"
   resolved "https://registry.npmjs.org/co/-/co-4.6.0.tgz"
@@ -8470,6 +8475,13 @@ react-scripts@5.0.1:
     workbox-webpack-plugin "^6.4.1"
   optionalDependencies:
     fsevents "^2.3.2"
+
+react-toastify@^9.1.2:
+  version "9.1.2"
+  resolved "https://registry.yarnpkg.com/react-toastify/-/react-toastify-9.1.2.tgz#293aa1f952240129fe485ae5cb2f8d09c652cf3f"
+  integrity sha512-PBfzXO5jMGEtdYR5jxrORlNZZe/EuOkwvwKijMatsZZm8IZwLj01YvobeJYNjFcA6uy6CVrx2fzL9GWbhWPTDA==
+  dependencies:
+    clsx "^1.1.1"
 
 react@^18.2.0:
   version "18.2.0"


### PR DESCRIPTION
- 이메일 인증 모달 서버 측에서 보내는 로딩 시간에 맞춰서 구현
- 관리자 스테이스 페이지에서 리스트 모달의 닫히는 영역 재설정
- 모든 페이지에서 어드민 권한 제한을 어드민 || 매니저로 설정